### PR TITLE
OUT-105 | Remove portalId from request and take from /workspaces API

### DIFF
--- a/services/workspace.ts
+++ b/services/workspace.ts
@@ -5,7 +5,7 @@ import { CopilotAPI } from '@/utils/copilotApiUtils';
 import { z } from 'zod';
 
 // Fetch workspace from API
-export async function getWorkspaceInfo({ token }: APIProps): Promise<WorkspaceResponse> {
+export async function getWorkspaceInfo({ token }: { token: string }): Promise<WorkspaceResponse> {
   const copilotClient = new CopilotAPI(z.string().parse(token));
   return await copilotClient.getWorkspace();
 }

--- a/src/app/api/client-profile-updates/route.ts
+++ b/src/app/api/client-profile-updates/route.ts
@@ -20,7 +20,10 @@ export async function POST(request: NextRequest) {
     const clientUpdateResponse = await copilotClient.updateClient(clientProfileUpdateRequest.data.clientId, {
       customFields: clientProfileUpdateRequest.data.form,
     });
-    const changedFields = getObjectDifference(clientUpdateResponse.customFields ?? {}, client.customFields ?? {});
+    const changedFields = getObjectDifference(
+      (clientUpdateResponse.customFields ?? {}) as Record<string, any>,
+      (client.customFields ?? {}) as Record<string, any>,
+    );
     if (Object.keys(changedFields).length === 0) {
       return NextResponse.json({});
     }
@@ -30,7 +33,7 @@ export async function POST(request: NextRequest) {
       clientId: clientProfileUpdateRequest.data.clientId,
       companyId: clientProfileUpdateRequest.data.companyId,
       portalId: clientProfileUpdateRequest.data.portalId,
-      customFields: clientUpdateResponse.customFields ?? {},
+      customFields: (clientUpdateResponse.customFields ?? {}) as Record<string, any>,
       changedFields,
     });
 

--- a/src/app/manage/page.tsx
+++ b/src/app/manage/page.tsx
@@ -3,8 +3,8 @@ import { ManagePageContainer } from './views/ManagePageContainer';
 import { SimpleButton } from '@/components/styled/SimpleButton';
 import { apiUrl } from '@/config';
 import { CustomFieldAccessResponse } from '@/types/customFieldAccess';
-import { Settings } from '@mui/icons-material';
 import { ProfileLinks } from '@/types/settings';
+import { getWorkspaceInfo } from '../../../services/workspace';
 
 export const revalidate = 0;
 
@@ -48,10 +48,12 @@ async function getClient(clientId: string, token: string) {
 }
 
 export default async function ManagePage({ searchParams }: { searchParams: { token: string; portalId: string } }) {
-  const { token, portalId } = searchParams;
+  const { token } = searchParams;
 
+  const { id: portalId } = await getWorkspaceInfo({ token });
   const settings = await getSettings({ token, portalId }).then((s) => s?.profileLinks || []);
   const customFieldAccess = await getCustomFieldAccess({ token, portalId });
+
   // static for now, will be dynamic later after some API decisions are made
   const clientId = 'a583a0d0-de70-4d14-8bb1-0aacf7424e2c';
   const companyId = '52eb75a9-2790-4e37-aa7a-c13f7bc3aa91';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,12 +63,13 @@ async function getSettings({ token, portalId }: { token: string; portalId: strin
 }
 
 export default async function Home({ searchParams }: { searchParams: { token: string; portalId: string } }) {
-  const { token, portalId } = searchParams;
+  const { token } = searchParams;
+  const workspace = await getWorkspaceInfo({ token });
+  const { id: portalId } = workspace;
 
   const clientProfileUpdates = await getClientProfileUpdates({ token, portalId });
   const customFieldAccess = await getCustomFieldAccess({ token, portalId });
   const settings = await getSettings({ token, portalId });
-  const workspace = await getWorkspaceInfo({ token, portalId });
 
   return (
     <ContextUpdate

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -47,7 +47,7 @@ export const AppContextProvider: FC<IAppCoreProvider> = ({ children }) => {
     mutableSettings: [],
     token: '',
     portalId: '',
-    workspace: { isCompaniesEnabled: undefined },
+    workspace: { isCompaniesEnabled: undefined, id: '' },
   });
 
   return (

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -47,7 +47,7 @@ export const AppContextProvider: FC<IAppCoreProvider> = ({ children }) => {
     mutableSettings: [],
     token: '',
     portalId: '',
-    workspace: { isCompaniesEnabled: undefined, id: '' },
+    workspace: { id: '' },
   });
 
   return (

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -46,7 +46,8 @@ export const ClientResponseSchema = z.object({
   companyId: z.string(),
   status: z.string(),
   avatarImageUrl: z.string().nullable(),
-  customFields: z.record(z.string(), z.union([z.string(), z.array(z.string())])).nullable(),
+  customFields: z.record(z.string(), z.union([z.string(), z.array(z.string())]).nullable()).nullish(),
+  // customFields: z.any(),
 });
 export type ClientResponse = z.infer<typeof ClientResponseSchema>;
 
@@ -96,6 +97,7 @@ export const ClientRequestSchema = z.object({
   givenName: z.string().optional(),
   familyName: z.string().optional(),
   companyId: z.string().uuid().optional(),
-  customFields: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  customFields: z.record(z.union([z.string(), z.array(z.string())]).nullable()).nullish(),
+  // customFields: z.any(),
 });
 export type ClientRequest = z.infer<typeof ClientRequestSchema>;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -18,9 +18,9 @@ export type MeResponse = z.infer<typeof MeResponseSchema>;
 
 // Response schema for `/workspace` endpoint
 export const WorkspaceResponseSchema = z.object({
+  id: z.string(),
   isCompaniesEnabled: z.boolean().optional(),
   // For future use
-  // id: z.string(),
   // industry: z.string().optional(),
   // isClientDirectSignUpEnabled: z.boolean().optional(),
   // logOutUrl: z.string().optional(),


### PR DESCRIPTION
Ref: [OUT-105](https://linear.app/copilotplatforms/issue/OUT-105/remove-portalid-from-request-and-take-from-workspaces-api)

Changes:
- Parse workspace / portal id from `getWorkspaceInfo` instead of relying on url param