### PR TITLE
OUT-107 | Server Component Render error on Profile Manager in prod

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -96,6 +96,6 @@ export const ClientRequestSchema = z.object({
   givenName: z.string().optional(),
   familyName: z.string().optional(),
   companyId: z.string().uuid().optional(),
-  customFields: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  customFields: z.record(z.union([z.string(), z.array(z.string())])).nullish(),
 });
 export type ClientRequest = z.infer<typeof ClientRequestSchema>;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -46,7 +46,7 @@ export const ClientResponseSchema = z.object({
   companyId: z.string(),
   status: z.string(),
   avatarImageUrl: z.string().nullable(),
-  customFields: z.record(z.string(), z.union([z.string(), z.array(z.string())])).nullable(),
+  customFields: z.record(z.string(), z.union([z.string(), z.array(z.string())]).nullable()).nullish(),
 });
 export type ClientResponse = z.infer<typeof ClientResponseSchema>;
 
@@ -96,6 +96,6 @@ export const ClientRequestSchema = z.object({
   givenName: z.string().optional(),
   familyName: z.string().optional(),
   companyId: z.string().uuid().optional(),
-  customFields: z.record(z.union([z.string(), z.array(z.string())])).nullable(),
+  customFields: z.record(z.string(), z.union([z.string(), z.array(z.string())]).nullable()).nullish(),
 });
 export type ClientRequest = z.infer<typeof ClientRequestSchema>;


### PR DESCRIPTION
Ref: [OUT-107](https://linear.app/copilotplatforms/issue/OUT-107/server-component-render-error-on-profile-manager-in-prod)

Changes:
- Zod schema didn't allow for null value to be accepted in customFields