### PR TITLE
chore: fix the crash when company does not exist

### DIFF
--- a/src/app/api/client-profile-updates/route.ts
+++ b/src/app/api/client-profile-updates/route.ts
@@ -5,7 +5,7 @@ import { handleError, respondError } from '@/utils/common';
 import { ClientProfileUpdatesService } from '@/app/api/client-profile-updates/services/clientProfileUpdates.service';
 import { ClientResponse, CompanyResponse } from '@/types/common';
 import { z } from 'zod';
-import { createLookup, getObjectDifference, getSelectedOptions } from '@/lib/helper';
+import { createLookup, createMapLookup, getObjectDifference, getSelectedOptions } from '@/lib/helper';
 
 export async function POST(request: NextRequest) {
   const data = await request.json();
@@ -67,16 +67,16 @@ export async function GET(request: NextRequest) {
     const clientProfileUpdates = await new ClientProfileUpdatesService().findMany(portalId, []);
 
     const clientLookup = createLookup(clients.data, 'id');
-    const companyLookup = createLookup(companies.data, 'id');
+    const companyLookup = createMapLookup(companies.data, 'id');
 
     const parsedClientProfileUpdates: ParsedClientProfileUpdatesResponse[] = clientProfileUpdates.map((update) => {
       const client = clientLookup[update.clientId];
-      const company = companyLookup[update.companyId];
+      const company = companyLookup.get(update.companyId);
 
       let parsedClientProfileUpdate: ParsedClientProfileUpdatesResponse = {
         id: update.id,
         client: getClientDetails(client),
-        company: getCompanyDetails(company),
+        company: company ? getCompanyDetails(company) : undefined,
         lastUpdated: update.createdAt,
       };
 

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -29,14 +29,12 @@ export function createMapLookup<T extends Record<string, unknown>>(
   array: T[] | undefined | null,
   key: string,
 ): Map<string, T> {
-  const mapItems = (array ?? [])
-    .map((item) => {
-      if (key in item) return [item[key], item];
-      return null;
-    })
-    .filter(Boolean);
-  const lookup: Map<string, any> = new Map();
-  return lookup;
+  const result = new Map();
+  if (!array) return result;
+  for (const item of array) {
+    result.set(item[key], item);
+  }
+  return result;
 }
 
 export function getSelectedOptions(portalCustomField: CustomField, value: string | string[]) {

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -25,6 +25,20 @@ export function createLookup(array: any[] | undefined | null, key: string): Reco
   return lookup;
 }
 
+export function createMapLookup<T extends Record<string, unknown>>(
+  array: T[] | undefined | null,
+  key: string,
+): Map<string, T> {
+  const mapItems = (array ?? [])
+    .map((item) => {
+      if (key in item) return [item[key], item];
+      return null;
+    })
+    .filter(Boolean);
+  const lookup: Map<string, any> = new Map();
+  return lookup;
+}
+
 export function getSelectedOptions(portalCustomField: CustomField, value: string | string[]) {
   const options: unknown[] = [];
 

--- a/src/types/clientProfileUpdates.ts
+++ b/src/types/clientProfileUpdates.ts
@@ -41,11 +41,13 @@ export const ParsedClientProfileUpdatesResponseSchema = z.object({
     email: z.string(),
     avatarImageUrl: z.string().nullable(),
   }),
-  company: z.object({
-    id: z.string().uuid(),
-    name: z.string(),
-    iconImageUrl: z.string().nullable(),
-  }),
+  company: z
+    .object({
+      id: z.string().uuid(),
+      name: z.string(),
+      iconImageUrl: z.string().nullable(),
+    })
+    .optional(),
   lastUpdated: z.date(),
 });
 export type ParsedClientProfileUpdatesResponse = z.infer<typeof ParsedClientProfileUpdatesResponseSchema>;


### PR DESCRIPTION
There was an error in the Vercel logs, cannot read property 'id' of undefined. After looking at the code, I determined there was an incorrect assumption that companyId would always exist on every client. That, however, is not the case.

To fix this I added a helper function `createMapLookup` that leverages a Map data structure to allow Typescript to correctly type company as potentially undefined when looking it up in the map.