### PR TITLE
OUT-168 | Show a loading spinner when profile manager is loading on the client-side

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,11 @@
+import { Box, CircularProgress } from '@mui/material';
+
+const Loading = () => {
+  return (
+    <Box sx={{ width: '100vw', height: '100vh', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+      <CircularProgress size={40} color="inherit" />
+    </Box>
+  );
+};
+
+export default Loading;


### PR DESCRIPTION
Ref: [OUT-168](https://linear.app/copilotplatforms/issue/OUT-168/show-a-loading-spinner-when-profile-manager-is-loading-on-the-client)

Changes:
- Add loader using suspense