### PR TITLE
OUT-1034 | Investigate profile manager issues reported by users

### DIFF
--- a/src/app/api/client-profile-updates/route.ts
+++ b/src/app/api/client-profile-updates/route.ts
@@ -132,8 +132,10 @@ export async function GET(request: NextRequest) {
 
       return parsedClientProfileUpdate;
     });
-
-    return NextResponse.json(parsedClientProfileUpdates);
+    // If any client is deleted in Copilot, we can't fetch the client data for it.
+    // Filter them out of the array to only show active client profile updates
+    const activeClientProfileUpdates = parsedClientProfileUpdates.filter((profile) => !!profile.client);
+    return NextResponse.json(activeClientProfileUpdates);
   } catch (error) {
     return handleError(error);
   }


### PR DESCRIPTION
## Changes
- For deleted clients, table data for that client was simply being returned as `undefined`, so the table couldn't render properties of an `undefined` client.
- Filtered out undefined clients from API side

Testing Criteria:
- Screencast with empty updates + new profile update + client deletion flow:
[Screencast from 2024-11-14 15-47-52.webm](https://github.com/user-attachments/assets/843f436b-c86c-418a-b4c2-a78983a23f3d)

