### PR TITLE
OUT-1763 | PrismaClientUnknownRequestError: Control plane request failed

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,11 +6,13 @@ generator client {
 }
 
 datasource db {
-  provider  = "postgresql"
+  provider     = "postgresql"
   // Vercel won't let us change the POSTGRES_* config so update it with a connection_limit key using a custom env var like
   // POSTGRES_PRISMA_URL_HIGHER_CONNECTION_LIMIT="$POSTGRES_PRISMA_URL&connection_limit=20"
-  url       = env("POSTGRES_PRISMA_URL_HIGHER_CONNECTION_LIMIT")
-  directUrl = env("POSTGRES_URL_NON_POOLING")
+  url          = env("POSTGRES_PRISMA_URL_HIGHER_CONNECTION_LIMIT")
+  directUrl    = env("POSTGRES_URL_NON_POOLING")
+  // Emulates relationships in Prisma client itself. Better for serverless databases like neon or planetscale
+  relationMode = "prisma"
 }
 
 enum Permission {


### PR DESCRIPTION
## Changes:
- Default relationMode to "prisma", making the Prisma rust client perform all JOINs internally. This seems to be a much more suitable option for serverless db's like Vercel Postgres (NeonDB)

### Ref:

https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/relation-mode