### PR TITLE
OUT-3975 | Profile Manager App - Company custom fields are showing but tags are not

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -114,6 +114,7 @@ export const CustomFieldSchema = z.object({
       }),
     )
     .optional(),
+  entityType: z.string(),
 });
 export type CustomField = z.infer<typeof CustomFieldSchema>;
 export const CustomFieldResponseSchema = z.object({

--- a/src/utils/copilotApiUtils.ts
+++ b/src/utils/copilotApiUtils.ts
@@ -70,6 +70,7 @@ export class CopilotAPI {
   }
 
   async getCustomFields(): Promise<CustomFieldResponse> {
-    return CustomFieldResponseSchema.parse(await this.copilot.listCustomFields());
+    const response = CustomFieldResponseSchema.parse(await this.copilot.listCustomFields());
+    return { ...response, data: response.data?.filter((field) => field.entityType === 'client') ?? [] };
   }
 }


### PR DESCRIPTION


#### The main changes are

- [x] filtered custom field to only fetch custom fields related to client, previously company custom fields were also shown which was never intended.


### Testing 

Company Phone Number is a custom field for company: 
<img width="1173" height="244" alt="image" src="https://github.com/user-attachments/assets/f98b7cb1-c847-4b7e-8713-3bcdde80f86f" />


IU View (old): 
<img width="1199" height="713" alt="image" src="https://github.com/user-attachments/assets/bb087410-a2e8-4582-9ac4-be3f438d37f9" />


IU View (fixed, filtered custom field for company): 
<img width="737" height="373" alt="image" src="https://github.com/user-attachments/assets/0f1a86c4-0c71-4bfb-840a-ba2142a0cc63" />


CU View (old): 
<img width="1141" height="724" alt="image" src="https://github.com/user-attachments/assets/3b374bb1-3504-4cc4-897c-81def20e589b" />


CU View (fixed, filtered custom field for company): 
<img width="1290" height="777" alt="image" src="https://github.com/user-attachments/assets/1dc1f74a-488e-45dc-bbfc-5054bc08461b" />


